### PR TITLE
Switching the Empathy Workshop to use the VCS workflow for the stark-enterprises workspace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,11 +10,17 @@ module "projects" {
   organization_name = var.organization_name
 }
 
+module "vcs" {
+  source = "./vcs"
+
+  organization_name = var.organization_name
+}
+
 module "registry" {
   source = "./registry"
 
   github_username = var.github_username
-  oauth_token_id = var.oauth_token
+  oauth_token_id = module.vcs.oauth_token_id
   organization_name = var.organization_name
 }
 
@@ -22,7 +28,7 @@ module "workspaces" {
   source = "./workspaces"
 
   github_username = var.github_username
-  oauth_token_id = var.oauth_token
+  oauth_token_id = module.vcs.oauth_token_id
   token = var.token
   organization_name = var.organization_name
   hostname = var.hostname

--- a/main.tf
+++ b/main.tf
@@ -10,18 +10,11 @@ module "projects" {
   organization_name = var.organization_name
 }
 
-module "vcs" {
-  source = "./vcs"
-
-  oauth_token = var.github_token
-  organization_name = var.organization_name
-}
-
 module "registry" {
   source = "./registry"
 
   github_username = var.github_username
-  oauth_token_id = module.vcs.oauth_token_id
+  oauth_token_id = var.oauth_token
   organization_name = var.organization_name
 }
 
@@ -29,7 +22,7 @@ module "workspaces" {
   source = "./workspaces"
 
   github_username = var.github_username
-  oauth_token_id = module.vcs.oauth_token_id
+  oauth_token_id = var.oauth_token
   token = var.token
   organization_name = var.organization_name
   hostname = var.hostname

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,13 +1,4 @@
 terraform {
-  cloud {
-    hostname = "app.staging.terraform.io"
-    organization = "<INSERT_ORG_NAME_HERE>"
-
-    workspaces {
-      name = "hq"
-    }
-  }
-
   required_providers {
     tfe = "~> 0.44.1"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,3 @@
-variable "oauth_token" {
-  type = string
-  sensitive = true
-  description = "The OAuth token for a VCS connection"
-}
-
 variable "github_username" {
   type = string
   description = "The Github username that owns the repositories that will be used"

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
-variable "github_token" {
+variable "oauth_token" {
   type = string
   sensitive = true
-  description = "A Github Personal Access token"
+  description = "The OAuth token for a VCS connection"
 }
 
 variable "github_username" {

--- a/vcs/main.tf
+++ b/vcs/main.tf
@@ -1,0 +1,4 @@
+data "tfe_oauth_client" "github" {
+  organization = var.organization_name
+  name = "ipl-empathy-workshop"
+}

--- a/vcs/main.tf
+++ b/vcs/main.tf
@@ -1,8 +1,0 @@
-resource "tfe_oauth_client" "github" {
-  name = "ipl-empathy-session-github-client"
-  organization = var.organization_name
-  api_url = "https://api.github.com"
-  http_url = "https://github.com"
-  oauth_token = var.oauth_token
-  service_provider = "github"
-}

--- a/vcs/outputs.tf
+++ b/vcs/outputs.tf
@@ -1,3 +1,0 @@
-output "oauth_token_id" {
-  value = tfe_oauth_client.github.oauth_token_id
-}

--- a/vcs/outputs.tf
+++ b/vcs/outputs.tf
@@ -1,0 +1,3 @@
+output "oauth_token_id" {
+  value = data.tfe_oauth_client.github.oauth_token_id
+}

--- a/vcs/variables.tf
+++ b/vcs/variables.tf
@@ -1,0 +1,4 @@
+variable "organization_name" {
+  type = string
+  description = "The name of the TFC organization"
+}

--- a/vcs/variables.tf
+++ b/vcs/variables.tf
@@ -1,9 +1,0 @@
-variable "oauth_token" {
-  type = string
-  sensitive = true
-}
-
-variable "organization_name" {
-  type = string
-  description = "The name of the TFC organization"
-}


### PR DESCRIPTION
I've updated the workflow to use the VCS workflow for the stark-enterprises repo, which means the users will need to configure the VCS workflow, but that is a little more of a guided process than requiring the user to generate a PAT.

Testers of our initial workflow mentioned the process to install Terraform on their local CLIs was tedious, and there were a lot of steps to get set up to use the CLI workflow. So I updated the steps to instead use the VCS workflow, which reduced the number of steps significantly. So now users must configure their VCS connection with a specific name, and we will use a data source to look up that oauth client and grab its oauth_token_id